### PR TITLE
chore: drop support for EOL Node.js 14.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [16.x, 17.x, 18.x, 19.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node.js 14.x and 15.x