### PR TITLE
fix: do not use colons or slashes in IDs

### DIFF
--- a/bin/verify
+++ b/bin/verify
@@ -44,6 +44,16 @@ const artistIds = getSet('artists')
 const releaseIds = getSet('releases')
 const individualIds = getSet('individuals')
 
+// All IDs are strings but must not contain colons or slashes because the visualizer
+// uses IDs as directory names.
+const validateIds = (idsSet) => {
+  assert.ok(idsSet.values().every((id) => typeof id === 'string' && !id.includes(':') && !id.includes('/')), 'Invalid ID found')
+}
+validateIds(trackIds)
+validateIds(artistIds)
+validateIds(individualIds)
+validateIds(releaseIds)
+
 const artistTrackIds = {
   artist: getSet('artist_track', { idName: 'artist_id', ignoreDuplicates: true }),
   track: getSet('artist_track', { idName: 'track_id', ignoreDuplicates: true })

--- a/data/individuals.json
+++ b/data/individuals.json
@@ -30824,9 +30824,9 @@
     ]
   },
   {
-    "_id": "Steve Earle (American singer/songwriter)",
+    "_id": "Steve Earle (American singer-songwriter)",
     "names": [
-      "Steve Earle (American singer/songwriter)"
+      "Steve Earle (American singer-songwriter)"
     ]
   },
   {
@@ -31844,9 +31844,9 @@
     ]
   },
   {
-    "_id": "Jack Johnson (singer/songwriter)",
+    "_id": "Jack Johnson (singer-songwriter)",
     "names": [
-      "Jack Johnson (singer/songwriter)"
+      "Jack Johnson (singer-songwriter)"
     ]
   },
   {


### PR DESCRIPTION
The visualizer uses IDs for directory names so we must disallow colons and slashes in IDs.